### PR TITLE
Removed schains from buildRequests

### DIFF
--- a/modules/yieldloveBidAdapter.js
+++ b/modules/yieldloveBidAdapter.js
@@ -42,8 +42,6 @@ export const spec = {
         }
     })
 
-    const schains = anyValidBidRequest.schain ? [{bidders: ["*"], schain:anyValidBidRequest.schain}] : []
-
     const s2sRequest = {
       device: {
         ua: window.navigator.userAgent,
@@ -67,7 +65,6 @@ export const spec = {
           storedrequest: {
             id: anyValidBidRequest.params.rid
           },
-          schains
         }
       },
       user: {


### PR DESCRIPTION
Ideally, the `ext.prebid.schains` should inlcude two nodes.
One represents publisher if it exists.
The other one represents yieldlove.com
according to [feat/schain/2023-04](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md#sample-resale-of-bidrequest1-bidrequest2-seller--resellercom)

However, currently, we don't have the mechanism to get the info for the node of yieldlove.com (the sellers id is different for different publishers) 
and when `ext.prebid.schains` exists in both bid request and the stored request, the setting from stored request is overwritten. 

So, the decision is to remove the `ext.prebid.schains` from the adapter side.
In the short term, the configuration is hard-coded in the stored request.
For the long term solution, we will discuss the solution again when we have more publishers using this solution. 